### PR TITLE
Fix ruff lint failures in pipeline scripts

### DIFF
--- a/packages/pipeline/scripts/generate_geojson.py
+++ b/packages/pipeline/scripts/generate_geojson.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import json
 import os
 import subprocess
@@ -69,7 +68,7 @@ def main():
             with open(output_path, "w") as f:
                 json.dump(geojson, f)
             print(f"Wrote {output_path}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - one data type's failure shouldn't abort the others
             print(f"Error fetching {data_type}: {e}", file=sys.stderr)
 
     r2_bucket = os.environ.get("R2_BUCKET")

--- a/packages/pipeline/scripts/generate_pmtiles.py
+++ b/packages/pipeline/scripts/generate_pmtiles.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Generate PMTiles from SNODAS COG files.
 
@@ -12,17 +11,17 @@ Requirements:
 """
 
 import argparse
-import subprocess
-from pathlib import Path
-import tempfile
 import multiprocessing as mp
+import subprocess
+import tempfile
 from functools import partial
+from pathlib import Path
 
 
 def apply_color_ramp(input_path: Path, output_path: Path) -> None:
     """Apply snow depth color ramp to COG and save as RGB GeoTIFF."""
-    import rasterio
     import numpy as np
+    import rasterio
 
     with rasterio.open(input_path) as src:
         data = src.read(1)
@@ -108,11 +107,11 @@ def process_single_file(args: tuple, pmtiles_dir: Path, zoom_levels: str) -> str
     try:
         generate_pmtiles(cog_file, pmtiles_file, zoom_levels)
         return f"Done {date}"
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - one file's failure shouldn't abort the batch
         return f"Error {date}: {e}"
 
 
-def batch_process(cog_dir: Path, pmtiles_dir: Path, zoom_levels: str = "4..10", workers: int = None) -> None:
+def batch_process(cog_dir: Path, pmtiles_dir: Path, zoom_levels: str = "4..10", workers: int | None = None) -> None:
     """Process all COG files in a directory using multiprocessing."""
     pmtiles_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- The daily pipeline workflow's `ruff check packages/pipeline/scripts/` step was failing, blocking the whole run before it ever got to processing the day's data.
- `generate_geojson.py` and `generate_pmtiles.py` had a shebang line despite never being executed directly (both are always invoked as `python3 script.py`), unsorted imports, an implicit-`Optional` default, and blind `except Exception` catches with no explanation.

## Changes
- Removed the unused `#!/usr/bin/env python3` shebangs (`EXE001`).
- Sorted the import blocks in `generate_pmtiles.py` (`I001`).
- Changed `workers: int = None` to `workers: int | None = None` (`RUF013`).
- Annotated the two intentional per-item catch-alls with `# noqa: BLE001`, since both are deliberate batch boundaries where one item's failure shouldn't abort the rest.

## Test plan
- [x] `ruff check packages/pipeline/scripts/` passes locally with no errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ApD9W2HAUjcsjNZSyLZ3Yy)_