### PR TITLE
Fix daily pipeline failing on GitHub Actions schedule delays

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -75,10 +75,17 @@ jobs:
           fi
 
       - name: Run pipeline for date
+        id: run
         run: |
           DATE="${{ steps.dates.outputs.date }}"
           echo "Processing date: $DATE"
-          bun run pipeline:daily -- --date $DATE
+          if ! bun run pipeline:daily -- --date "$DATE"; then
+            echo "Data for $DATE not available yet, falling back to previous day"
+            DATE=$(date -d "$DATE -1 day" +%Y-%m-%d)
+            echo "Processing date: $DATE"
+            bun run pipeline:daily -- --date "$DATE"
+          fi
+          echo "date=$DATE" >> $GITHUB_OUTPUT
 
       - name: Build Zarr (append to R2)
         id: zarr
@@ -121,13 +128,13 @@ jobs:
           server_port: 587
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}
-          subject: "GnarMap Pipeline Complete - ${{ steps.dates.outputs.date }}"
+          subject: "GnarMap Pipeline Complete - ${{ steps.run.outputs.date }}"
           to: ${{ secrets.NOTIFICATION_EMAIL }}
           from: GnarMap Pipeline <${{ secrets.EMAIL_USERNAME }}>
           body: |
             GnarMap daily pipeline completed successfully!
 
-            Date processed: ${{ steps.dates.outputs.date }}
+            Date processed: ${{ steps.run.outputs.date }}
 
             R2 updates:
             - Zarr time series: ${{ steps.zarr.outputs.status }}


### PR DESCRIPTION
## Summary
- The daily pipeline defaults to processing "today's" date, assuming the scheduled run fires mid-day, after NSIDC has published that day's SNODAS file.
- GitHub Actions has been delaying the 16:00 UTC cron trigger by several hours; the last two scheduled runs fired at ~00:30 UTC instead, before the target date's data existed, and hard-failed with `HTTP 404`.
- The pipeline step now retries with the previous day's date if the first attempt fails, and downstream steps (email subject/body) reference whichever date actually succeeded.

## Test plan
- [x] Verified both previously-failing dates (2026-08-28, 2026-08-29) now return `200 OK` from NSIDC, confirming the data publishes later than the run time, not that it's missing.
- [x] Validated workflow YAML syntax.
- [ ] Confirm the next scheduled run (or a manual re-run) completes successfully with the fallback logic if it fires early again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)